### PR TITLE
rename librairies variable for libmysqlclient-dev

### DIFF
--- a/vars/mysql.yml
+++ b/vars/mysql.yml
@@ -2,13 +2,13 @@
 redmine_apt_packages:
 - redmine
 - redmine-mysql
-- libmysqlclient-dev
+- default-libmysqlclient-dev
 
 redmine_git_packages:
 - git
 - ruby-dev
 - make
-- libmysqlclient-dev
+- default-libmysqlclient-dev
 - libmagickcore-dev
 - libmagickwand-dev
 - imagemagick


### PR DESCRIPTION
After changing the name of the following libmysqlclient-dev library to default-libmysqlclient-dev, deployment didn't work because the library couldn't be found. 